### PR TITLE
Provide implementation that creates dummy transactions

### DIFF
--- a/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/alfresco-global.properties
+++ b/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/alfresco-global.properties
@@ -1,4 +1,4 @@
 eu.xenit.alfresco.anti-idle.cronexpression=0 0 * * * ?
-eu.xenit.alfresco.anti-idle.cronstartdelay=24000
+eu.xenit.alfresco.anti-idle.cronstartdelay=60000
 eu.xenit.alfresco.anti-idle.enabled=true
-eu.xenit.alfresco.anti-idle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document
+eu.xenit.alfresco.anti-idle.fileLocation=/Anti Idle/Dummy Document

--- a/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/alfresco-global.properties
+++ b/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/alfresco-global.properties
@@ -1,3 +1,4 @@
-eu.xenit.alfresco.antiidle.cronexpression=*/30 * * * * ?
+eu.xenit.alfresco.antiidle.cronexpression=0 0 * * * ?
 eu.xenit.alfresco.antiidle.cronstartdelay=24000
+eu.xenit.alfresco.antiidle.enabled=true
 eu.xenit.alfresco.antiidle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document

--- a/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/alfresco-global.properties
+++ b/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/alfresco-global.properties
@@ -1,4 +1,4 @@
-eu.xenit.alfresco.antiidle.cronexpression=0 0 * * * ?
-eu.xenit.alfresco.antiidle.cronstartdelay=24000
-eu.xenit.alfresco.antiidle.enabled=true
-eu.xenit.alfresco.antiidle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document
+eu.xenit.alfresco.anti-idle.cronexpression=0 0 * * * ?
+eu.xenit.alfresco.anti-idle.cronstartdelay=24000
+eu.xenit.alfresco.anti-idle.enabled=true
+eu.xenit.alfresco.anti-idle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document

--- a/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/alfresco-global.properties
+++ b/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/alfresco-global.properties
@@ -1,2 +1,3 @@
-eu.xenit.alfresco.antiidle.cronexpression=* * * * * ?
-eu.xenit.alfresco.antiidle.cronstartdelay=0
+eu.xenit.alfresco.antiidle.cronexpression=*/30 * * * * ?
+eu.xenit.alfresco.antiidle.cronstartdelay=24000
+eu.xenit.alfresco.antiidle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document

--- a/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/module-context.xml
+++ b/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/module-context.xml
@@ -8,8 +8,8 @@
         <property name="serviceRegistry">
             <ref bean="ServiceRegistry" />
         </property>
-        <property name="fileLocation" value="${eu.xenit.alfresco.antiidle.fileLocation}" />
-        <property name="enabled" value="${eu.xenit.alfresco.antiidle.enabled}" />
+        <property name="fileLocation" value="${eu.xenit.alfresco.anti-idle.fileLocation}" />
+        <property name="enabled" value="${eu.xenit.alfresco.anti-idle.enabled}" />
     </bean>
 
     <bean id="eu.xenit.alfresco.AntiIdleJobDetail"
@@ -28,8 +28,8 @@
     <bean id="eu.xenit.alfresco.AntiIdleTrigger"
             class="org.springframework.scheduling.quartz.CronTriggerBean">
         <property name="jobDetail" ref="eu.xenit.alfresco.AntiIdleJobDetail" />
-        <property name="cronExpression" value="${eu.xenit.alfresco.antiidle.cronexpression}" />
-        <property name="startDelay" value="${eu.xenit.alfresco.antiidle.cronstartdelay}" />
+        <property name="cronExpression" value="${eu.xenit.alfresco.anti-idle.cronexpression}" />
+        <property name="startDelay" value="${eu.xenit.alfresco.anti-idle.cronstartdelay}" />
     </bean>
 
     <bean id="eu.xenit.alfresco.AntiIdleSchedulerFactoryBean" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">

--- a/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/module-context.xml
+++ b/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/module-context.xml
@@ -8,6 +8,7 @@
         <property name="serviceRegistry">
             <ref bean="ServiceRegistry" />
         </property>
+        <property name="fileLocation" value="${eu.xenit.alfresco.antiidle.fileLocation}" />
     </bean>
 
     <bean id="eu.xenit.alfresco.AntiIdleJobDetail"

--- a/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/module-context.xml
+++ b/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/module-context.xml
@@ -9,6 +9,7 @@
             <ref bean="ServiceRegistry" />
         </property>
         <property name="fileLocation" value="${eu.xenit.alfresco.antiidle.fileLocation}" />
+        <property name="enabled" value="${eu.xenit.alfresco.antiidle.enabled}" />
     </bean>
 
     <bean id="eu.xenit.alfresco.AntiIdleJobDetail"

--- a/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/alfresco-global.properties
+++ b/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/alfresco-global.properties
@@ -1,4 +1,4 @@
 eu.xenit.alfresco.anti-idle.cronexpression=0 0 * * * ?
-eu.xenit.alfresco.anti-idle.cronstartdelay=24000
+eu.xenit.alfresco.anti-idle.cronstartdelay=60000
 eu.xenit.alfresco.anti-idle.enabled=true
-eu.xenit.alfresco.anti-idle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document
+eu.xenit.alfresco.anti-idle.fileLocation=/Anti Idle/Dummy Document

--- a/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/alfresco-global.properties
+++ b/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/alfresco-global.properties
@@ -1,4 +1,4 @@
-eu.xenit.alfresco.antiidle.cronexpression=*/30 * * * * ?
+eu.xenit.alfresco.antiidle.cronexpression=0 0 * * * ?
 eu.xenit.alfresco.antiidle.cronstartdelay=24000
 eu.xenit.alfresco.antiidle.enabled=true
 eu.xenit.alfresco.antiidle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document

--- a/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/alfresco-global.properties
+++ b/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/alfresco-global.properties
@@ -1,4 +1,4 @@
-eu.xenit.alfresco.antiidle.cronexpression=0 0 * * * ?
-eu.xenit.alfresco.antiidle.cronstartdelay=24000
-eu.xenit.alfresco.antiidle.enabled=true
-eu.xenit.alfresco.antiidle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document
+eu.xenit.alfresco.anti-idle.cronexpression=0 0 * * * ?
+eu.xenit.alfresco.anti-idle.cronstartdelay=24000
+eu.xenit.alfresco.anti-idle.enabled=true
+eu.xenit.alfresco.anti-idle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document

--- a/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/alfresco-global.properties
+++ b/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/alfresco-global.properties
@@ -1,3 +1,4 @@
-eu.xenit.alfresco.antiidle.cronexpression=* * * * * ?
-eu.xenit.alfresco.antiidle.cronstartdelay=0
+eu.xenit.alfresco.antiidle.cronexpression=*/30 * * * * ?
+eu.xenit.alfresco.antiidle.cronstartdelay=24000
 eu.xenit.alfresco.antiidle.enabled=true
+eu.xenit.alfresco.antiidle.fileLocation=/Company Home/Data Dictionary/Anti Idle/Dummy Document

--- a/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/module-context.xml
+++ b/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/module-context.xml
@@ -8,7 +8,7 @@
         <property name="serviceRegistry">
             <ref bean="ServiceRegistry" />
         </property>
-        <property name="fileLocation" value="${eu.xenit.alfresco.antiidle.fileLocation}" />
+        <property name="fileLocation" value="${eu.xenit.alfresco.anti-idle.fileLocation}" />
     </bean>
 
     <bean id="eu.xenit.alfresco.AntiIdleJobDetail"
@@ -27,8 +27,8 @@
     <bean id="eu.xenit.alfresco.AntiIdleTrigger"
             class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
         <property name="jobDetail" ref="eu.xenit.alfresco.AntiIdleJobDetail" />
-        <property name="cronExpression" value="${eu.xenit.alfresco.antiidle.cronexpression}" />
-        <property name="startDelay" value="${eu.xenit.alfresco.antiidle.cronstartdelay}" />
+        <property name="cronExpression" value="${eu.xenit.alfresco.anti-idle.cronexpression}" />
+        <property name="startDelay" value="${eu.xenit.alfresco.anti-idle.cronstartdelay}" />
     </bean>
 
     <bean id="eu.xenit.alfresco.AntiIdleSchedulerAccessor"
@@ -39,7 +39,7 @@
                 <ref bean="eu.xenit.alfresco.AntiIdleTrigger"/>
             </list>
         </property>
-        <property name="enabled" value="${eu.xenit.alfresco.antiidle.enabled}" />
+        <property name="enabled" value="${eu.xenit.alfresco.anti-idle.enabled}" />
     </bean>
 
 

--- a/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/module-context.xml
+++ b/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/module-context.xml
@@ -8,6 +8,7 @@
         <property name="serviceRegistry">
             <ref bean="ServiceRegistry" />
         </property>
+        <property name="fileLocation" value="${eu.xenit.alfresco.antiidle.fileLocation}" />
     </bean>
 
     <bean id="eu.xenit.alfresco.AntiIdleJobDetail"

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ configure(subprojects.findAll {it.name.contains("hotfix")}) {
     apply from: "${project.projectDir}/overload.gradle"
 
     description 'amp that creates dummy transactions'
+    version = rootProject.version
 
     sourceSets {
         main {

--- a/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
+++ b/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
@@ -26,8 +26,8 @@ import org.springframework.util.StringUtils;
 public class AntiIdleScheduledJobExecuter {
     private static final Logger LOG = LoggerFactory.getLogger(AntiIdleScheduledJobExecuter.class);
     private static final String defaultLocation = "/Company Home/Data Dictionary/Anti Idle/Dummy Document";
-    private String[] folder = new String[]{"Data Dictionary", "Anti Idle"};
-    private String fileName = "Dummy Document";
+    private String[] folder;
+    private String fileName;
     private boolean enabled = true;
     private NodeService nodeService;
     private NodeLocatorService nodeLocatorService;
@@ -49,22 +49,34 @@ public class AntiIdleScheduledJobExecuter {
     public void setFileLocation(String location) {
         if (StringUtils.isEmpty(location)) {
             LOG.debug("Custom location not set, using default " + defaultLocation);
+            setFolderAndFileName(toSegments(defaultLocation));
             return;
         }
-        List<String> segments = Arrays.stream(location.split("/"))
-                .filter(s -> !StringUtils.isEmpty(s))
-                .collect(Collectors.toList());
+        List<String> segments = toSegments(location);
         if (segments.size() < 2) {
             LOG.debug("Custom location should have at least 2 segments, using default " + defaultLocation);
+            setFolderAndFileName(toSegments(defaultLocation));
             return;
         }
-        if (!"Company Home".equals(segments.remove(0))) {
+        if (!"Company Home".equals(segments.get(0))) {
             LOG.debug("Only dummy files in Company Home tree supported for now, using default " + defaultLocation);
+            setFolderAndFileName(toSegments(defaultLocation));
             return;
         }
         LOG.debug("Setting location to " + location);
+        setFolderAndFileName(segments);
+    }
+
+    private void setFolderAndFileName(List<String> segments) {
+        segments.remove(0);
         fileName = segments.remove(segments.size() - 1);
         folder = segments.toArray(new String[0]);
+    }
+
+    private List<String> toSegments(String location) {
+        return Arrays.stream(location.split("/"))
+                .filter(s -> !StringUtils.isEmpty(s))
+                .collect(Collectors.toList());
     }
 
     public void setEnabled(boolean enabled) {

--- a/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
+++ b/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
@@ -63,8 +63,8 @@ public class AntiIdleScheduledJobExecuter {
     }
 
     private void setFolderAndFileName(List<String> segments) {
-        fileName = segments.remove(segments.size() - 1);
-        folder = segments.toArray(new String[0]);
+        fileName = segments.get(segments.size() - 1);
+        folder = segments.subList(0, segments.size() - 1).toArray(new String[0]);
     }
 
     private List<String> toSegments(String location) {

--- a/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
+++ b/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
@@ -1,11 +1,37 @@
 package eu.xenit.alfresco;
 
+import static org.alfresco.service.namespace.QName.createQName;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.nodelocator.CompanyHomeNodeLocator;
+import org.alfresco.repo.nodelocator.NodeLocatorService;
+import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.ChildAssociationRef;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.service.namespace.QName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 public class AntiIdleScheduledJobExecuter {
     private static final Logger LOG = LoggerFactory.getLogger(AntiIdleScheduledJobExecuter.class);
+    private static final String defaultLocation = "/Company Home/Data Dictionary/Anti Idle/Dummy Document";
+    private static String[] folder = new String[]{"Data Dictionary", "Anti Idle"};
+    private static String fileName = "Dummy Document";
+    private NodeService nodeService;
+    private NodeLocatorService nodeLocatorService;
+    private RetryingTransactionHelper retryingTransactionHelper;
+    private NodeRef nodeRef;
 
     /**
      * Public API access
@@ -14,12 +40,91 @@ public class AntiIdleScheduledJobExecuter {
 
     public void setServiceRegistry(ServiceRegistry serviceRegistry) {
         this.serviceRegistry = serviceRegistry;
+        this.nodeService = serviceRegistry.getNodeService();
+        this.nodeLocatorService = serviceRegistry.getNodeLocatorService();
+        this.retryingTransactionHelper = serviceRegistry.getRetryingTransactionHelper();
     }
+
+    public void setFileLocation(String location) {
+        if (StringUtils.isEmpty(location)) {
+            LOG.debug("Custom location not set, using default " + defaultLocation);
+        }
+        List<String> segments = Arrays.stream(location.split("/"))
+                .filter(s -> !StringUtils.isEmpty(s))
+                .collect(Collectors.toList());
+        if (segments.size() < 2) {
+            LOG.debug("Custom location should have at least 2 segments, using default " + defaultLocation);
+            return;
+        }
+        if (!"Company Home".equals(segments.get(0))) {
+            LOG.debug("Only dummy files in Company Home tree supported for now, using default " + defaultLocation);
+            return;
+        }
+        fileName = segments.remove(segments.size() - 1);
+        segments.remove(0);
+        folder = segments.toArray(new String[0]);
+    }
+
+
 
     /**
      * Executer implementation
      */
     public void execute() {
-        LOG.error("Running the scheduled job");
+        LOG.debug("Running " + this.getClass().getCanonicalName());
+        retryingTransactionHelper.doInTransaction(() -> {
+            if (nodeRef == null) {
+                nodeRef = createDummyDoc();
+                LOG.debug("Created " + nodeRef);
+            }
+            LOG.debug("Updating " + nodeRef);
+            updateDummyDoc(nodeRef);
+            return null;
+        });
     }
+
+    private NodeRef createDummyDoc() {
+        NodeRef parent = getFolderByDisplayPath(folder, true);
+        ChildAssociationRef node = nodeService.createNode(
+                parent,
+                ContentModel.ASSOC_CONTAINS,
+                createQName(
+                        NamespaceService.CONTENT_MODEL_1_0_URI,
+                        fileName),
+                ContentModel.PROP_CONTENT);
+        return node.getChildRef();
+    }
+
+    private void updateDummyDoc(NodeRef nodeRef) {
+        nodeService.setProperty(
+                nodeRef,
+                ContentModel.PROP_DESCRIPTION,
+                "I was updated to create a dummy transaction on " + LocalDateTime.now());
+    }
+
+    public NodeRef getFolderByDisplayPath(final String[] path, final boolean create) {
+        NodeRef cursor = nodeLocatorService.getNode(CompanyHomeNodeLocator.NAME, null, null);
+
+        for (String folder : path) {
+            NodeRef child = nodeService.getChildByName(cursor, ContentModel.ASSOC_CONTAINS, folder);
+            if (child != null) {
+                cursor = child;
+            } else if (create) {
+                Map<QName, Serializable> folderProp = new HashMap<>();
+                folderProp.put(ContentModel.PROP_NAME, folder);
+
+                cursor = nodeService.createNode(cursor,
+                        ContentModel.ASSOC_CONTAINS,
+                        createQName(NamespaceService.CONTENT_MODEL_1_0_URI, folder),
+                        ContentModel.TYPE_FOLDER,
+                        folderProp).getChildRef();
+            } else {
+                return null;
+            }
+        }
+
+        return cursor;
+    }
+
+
 }

--- a/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
+++ b/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
@@ -26,8 +26,9 @@ import org.springframework.util.StringUtils;
 public class AntiIdleScheduledJobExecuter {
     private static final Logger LOG = LoggerFactory.getLogger(AntiIdleScheduledJobExecuter.class);
     private static final String defaultLocation = "/Company Home/Data Dictionary/Anti Idle/Dummy Document";
-    private static String[] folder = new String[]{"Data Dictionary", "Anti Idle"};
-    private static String fileName = "Dummy Document";
+    private String[] folder = new String[]{"Data Dictionary", "Anti Idle"};
+    private String fileName = "Dummy Document";
+    private boolean enabled = true;
     private NodeService nodeService;
     private NodeLocatorService nodeLocatorService;
     private RetryingTransactionHelper retryingTransactionHelper;
@@ -60,17 +61,25 @@ public class AntiIdleScheduledJobExecuter {
             LOG.debug("Only dummy files in Company Home tree supported for now, using default " + defaultLocation);
             return;
         }
+        LOG.debug("Setting location to " + location);
         fileName = segments.remove(segments.size() - 1);
         segments.remove(0);
         folder = segments.toArray(new String[0]);
     }
 
-
+    public void setEnabled(boolean enabled) {
+        LOG.debug("setting enabled to " + enabled);
+        this.enabled = enabled;
+    }
 
     /**
      * Executer implementation
      */
     public void execute() {
+        if (!enabled) {
+            LOG.debug("Not running " + this.getClass().getCanonicalName() + ", not enabled");
+            return;
+        }
         LOG.debug("Running " + this.getClass().getCanonicalName());
         retryingTransactionHelper.doInTransaction(() -> {
             if (nodeRef == null) {

--- a/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
+++ b/core/src/main/java/eu/xenit/alfresco/AntiIdleScheduledJobExecuter.java
@@ -49,6 +49,7 @@ public class AntiIdleScheduledJobExecuter {
     public void setFileLocation(String location) {
         if (StringUtils.isEmpty(location)) {
             LOG.debug("Custom location not set, using default " + defaultLocation);
+            return;
         }
         List<String> segments = Arrays.stream(location.split("/"))
                 .filter(s -> !StringUtils.isEmpty(s))
@@ -57,13 +58,12 @@ public class AntiIdleScheduledJobExecuter {
             LOG.debug("Custom location should have at least 2 segments, using default " + defaultLocation);
             return;
         }
-        if (!"Company Home".equals(segments.get(0))) {
+        if (!"Company Home".equals(segments.remove(0))) {
             LOG.debug("Only dummy files in Company Home tree supported for now, using default " + defaultLocation);
             return;
         }
         LOG.debug("Setting location to " + location);
         fileName = segments.remove(segments.size() - 1);
-        segments.remove(0);
         folder = segments.toArray(new String[0]);
     }
 


### PR DESCRIPTION
On the first run:
A dummy document is created at a location specified in the alfresco-global.properties
default= /Company Home/Data Dictionary/Anti Idle/Dummy Document

On every run:
The description of this document is updated