### PR TITLE
Dynamic Extensions Quartz Scheduler Compatibility Fix

### DIFF
--- a/alfresco5-hotfix-ALF-22094/overload.gradle
+++ b/alfresco5-hotfix-ALF-22094/overload.gradle
@@ -3,5 +3,5 @@ ext {
     alfrescoImageDep = "xenit/alfresco-repository-community:5.2"
     alfrescoWarDep = "org.alfresco:alfresco-platform:5.2.g@war"
     alfrescoRepositoryDependency = "org.alfresco:alfresco-repository:5.2.g"
-    ampTask = ":alfresco5-hotfix-ALF-22094:amp"
+    quartz = "org.quartz-scheduler:quartz:1.8.3"
 }

--- a/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/module-context.xml
+++ b/alfresco5-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco5-hotfix-ALF-22094/module-context.xml
@@ -32,13 +32,7 @@
         <property name="startDelay" value="${eu.xenit.alfresco.anti-idle.cronstartdelay}" />
     </bean>
 
-    <bean id="eu.xenit.alfresco.AntiIdleSchedulerFactoryBean" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
-        <property name="triggers">
-            <list>
-                <ref bean="eu.xenit.alfresco.AntiIdleTrigger"/>
-            </list>
-        </property>
+    <bean id="eu.xenit.alfresco.AntiIdleTriggerRegistry" class="eu.xenit.alfresco.AntiIdleTriggerRegistry"
+          depends-on="eu.xenit.alfresco.AntiIdleTrigger">
     </bean>
-
-
 </beans>

--- a/alfresco5-hotfix-ALF-22094/src/main/java/eu/xenit/alfresco/AntiIdleTriggerRegistry.java
+++ b/alfresco5-hotfix-ALF-22094/src/main/java/eu/xenit/alfresco/AntiIdleTriggerRegistry.java
@@ -1,0 +1,39 @@
+package eu.xenit.alfresco;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.extensions.surf.util.AbstractLifecycleBean;
+import org.springframework.scheduling.quartz.CronTriggerBean;
+import org.springframework.scheduling.quartz.JobDetailBean;
+
+public class AntiIdleTriggerRegistry extends AbstractLifecycleBean {
+    private static final Logger LOG = LoggerFactory.getLogger(AntiIdleTriggerRegistry.class);
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @Autowired
+    @Qualifier("eu.xenit.alfresco.AntiIdleTrigger")
+    private CronTriggerBean trigger;
+
+    @Autowired
+    @Qualifier("eu.xenit.alfresco.AntiIdleJobDetail")
+    private JobDetailBean jobDetail;
+
+    @Override
+    protected void onBootstrap(ApplicationEvent event) {
+        try {
+            scheduler.scheduleJob(jobDetail, trigger);
+        } catch (SchedulerException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected void onShutdown(ApplicationEvent event) {}
+}

--- a/alfresco6-hotfix-ALF-22094/overload.gradle
+++ b/alfresco6-hotfix-ALF-22094/overload.gradle
@@ -3,5 +3,5 @@ ext {
     alfrescoImageDep = "xenit/alfresco-repository-community:6.1.2-ga"
     alfrescoWarDep = "org.alfresco:content-services-community:6.1.2-ga@war"
     alfrescoRepositoryDependency = "org.alfresco:alfresco-repository:8.157"
-    ampTask = ":alfresco6-hotfix-ALF-22094:amp"
+    quartz = "org.quartz-scheduler:quartz:2.3.0"
 }

--- a/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/module-context.xml
+++ b/alfresco6-hotfix-ALF-22094/src/main/amp/config/alfresco/module/alfresco6-hotfix-ALF-22094/module-context.xml
@@ -9,6 +9,7 @@
             <ref bean="ServiceRegistry" />
         </property>
         <property name="fileLocation" value="${eu.xenit.alfresco.anti-idle.fileLocation}" />
+        <property name="enabled" value="${eu.xenit.alfresco.anti-idle.enabled}" />
     </bean>
 
     <bean id="eu.xenit.alfresco.AntiIdleJobDetail"
@@ -31,16 +32,7 @@
         <property name="startDelay" value="${eu.xenit.alfresco.anti-idle.cronstartdelay}" />
     </bean>
 
-    <bean id="eu.xenit.alfresco.AntiIdleSchedulerAccessor"
-            class="org.alfresco.schedule.AlfrescoSchedulerAccessorBean">
-        <property name="scheduler" ref="schedulerFactory"/>
-        <property name="triggers">
-            <list>
-                <ref bean="eu.xenit.alfresco.AntiIdleTrigger"/>
-            </list>
-        </property>
-        <property name="enabled" value="${eu.xenit.alfresco.anti-idle.enabled}" />
+    <bean id="eu.xenit.alfresco.AntiIdleTriggerRegistry"  class="eu.xenit.alfresco.AntiIdleTriggerRegistry"
+          depends-on="eu.xenit.alfresco.AntiIdleTrigger">
     </bean>
-
-
 </beans>

--- a/alfresco6-hotfix-ALF-22094/src/main/java/eu/xenit/alfresco/AntiIdleTriggerRegistry.java
+++ b/alfresco6-hotfix-ALF-22094/src/main/java/eu/xenit/alfresco/AntiIdleTriggerRegistry.java
@@ -1,0 +1,39 @@
+package eu.xenit.alfresco;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.extensions.surf.util.AbstractLifecycleBean;
+import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
+import org.springframework.scheduling.quartz.JobDetailFactoryBean;
+
+public class AntiIdleTriggerRegistry extends AbstractLifecycleBean {
+    private static final Logger LOG = LoggerFactory.getLogger(AntiIdleTriggerRegistry.class);
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @Autowired
+    @Qualifier("eu.xenit.alfresco.AntiIdleTrigger")
+    private CronTriggerFactoryBean trigger;
+
+    @Autowired
+    @Qualifier("eu.xenit.alfresco.AntiIdleJobDetail")
+    private JobDetailFactoryBean jobDetail;
+
+    @Override
+    protected void onBootstrap(ApplicationEvent event) {
+        try {
+            scheduler.scheduleJob(jobDetail.getObject(), trigger.getObject());
+        } catch (SchedulerException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected void onShutdown(ApplicationEvent event) {}
+}

--- a/build.gradle
+++ b/build.gradle
@@ -62,13 +62,14 @@ configure(subprojects.findAll {it.name.contains("hotfix")}) {
 
     dependencies {
         alfrescoProvided("${alfRepoDep}")
+        alfrescoProvided("${quartz}")
         baseAlfrescoWar "${alfrescoWarDep}"
-        alfrescoAmp tasks.getByPath("${ampTask}").outputs.files
+        alfrescoAmp project.tasks.amp.outputs.files
     }
-}
 
-repositories {
-    mavenCentral()
+    repositories {
+        mavenCentral()
+    }
 }
 
 


### PR DESCRIPTION
Replaced the custom scheduler in Spring XML configuration with the default Quartz scheduler for Alfresco to provide compatibility with Dynamic Extensions