### PR TITLE
Added ACL update function to avoid Solr spam of underutilized environments

### DIFF
--- a/alfresco5-hotfix-ALF-22094/overload.gradle
+++ b/alfresco5-hotfix-ALF-22094/overload.gradle
@@ -2,6 +2,5 @@ ext {
     alfRepoDep = "org.alfresco:alfresco-repository:5.2.g"
     alfrescoImageDep = "xenit/alfresco-repository-community:5.2"
     alfrescoWarDep = "org.alfresco:alfresco-platform:5.2.g@war"
-    alfrescoRepositoryDependency = "org.alfresco:alfresco-repository:5.2.g"
     quartz = "org.quartz-scheduler:quartz:1.8.3"
 }

--- a/alfresco6-hotfix-ALF-22094/overload.gradle
+++ b/alfresco6-hotfix-ALF-22094/overload.gradle
@@ -2,6 +2,5 @@ ext {
     alfRepoDep = "org.alfresco:alfresco-repository:8.157"
     alfrescoImageDep = "xenit/alfresco-repository-community:6.1.2-ga"
     alfrescoWarDep = "org.alfresco:content-services-community:6.1.2-ga@war"
-    alfrescoRepositoryDependency = "org.alfresco:alfresco-repository:8.157"
     quartz = "org.quartz-scheduler:quartz:2.3.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id 'eu.xenit.alfresco' version "1.0.1" apply(false) // Have a look at https://plugins.gradle.org/plugin/eu.xenit.alfresco for the latest version
-    id 'eu.xenit.amp' version "1.0.1" apply(false)
-    id "eu.xenit.docker-alfresco" version "5.0.5" apply(false) // See https://plugins.gradle.org/plugin/eu.xenit.docker-alfresco for the latest version
-    id "eu.xenit.docker-compose.auto" version "5.0.5" apply(false) // See https://plugins.gradle.org/plugin/eu.xenit.docker-compose.auto for the latest version
+    id 'eu.xenit.alfresco' version "1.1.0" apply(false) // Have a look at https://plugins.gradle.org/plugin/eu.xenit.alfresco for the latest version
+    id 'eu.xenit.amp' version "1.1.0" apply(false)
+    id "eu.xenit.docker-alfresco" version "5.3.1" apply(false) // See https://plugins.gradle.org/plugin/eu.xenit.docker-alfresco for the latest version
+    id "eu.xenit.docker-compose.auto" version "5.3.1" apply(false) // See https://plugins.gradle.org/plugin/eu.xenit.docker-compose.auto for the latest version
 }
 
 group 'eu.xenit.alfresco'
 description = "Hotfix for ALF-22094, reduce access logs from Solr for an idle Alfresco"
 
-def baseVersion = "1.0.0"
+def baseVersion = "1.1.0"
 
 def branchName = System.env.BRANCH_NAME
 def isRelease = branchName != null && branchName.startsWith("release")
@@ -61,14 +61,17 @@ configure(subprojects.findAll {it.name.contains("hotfix")}) {
     }
 
     dependencies {
-        alfrescoProvided("${alfRepoDep}")
-        alfrescoProvided("${quartz}")
+        alfrescoProvided "${alfRepoDep}"
+        alfrescoProvided "${quartz}"
         baseAlfrescoWar "${alfrescoWarDep}"
         alfrescoAmp project.tasks.amp.outputs.files
     }
 
     repositories {
         mavenCentral()
+        maven {
+            url 'https://artifacts.alfresco.com/nexus/content/repositories/public/'
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,2 @@
-#Tue Apr 28 17:31:12 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists


### PR DESCRIPTION
We managed to avoid Solr spam of environments with low utilization by updating the metadata.
However, we missed that Solr also tracks the ACLs independently of the committed transactions.

This PR enables ACL updates on the dummy file to limit the Solr spam from long periods without inactivity.